### PR TITLE
Replace os.rmdir with shutil.rmtree for non-empty directory removal

### DIFF
--- a/stitcher.py
+++ b/stitcher.py
@@ -1,6 +1,7 @@
 import os
 from PIL import Image
 import time
+import shutil
 
 mangas = os.listdir("temp")
 
@@ -37,5 +38,5 @@ for manga in mangas:
         pdf_path, "PDF" ,resolution=100.0, save_all=True, append_images=images[1:]
     )
 
-    os.rmdir(f"temp/{manga}")
+    shutil.rmtree(f"temp/{manga}")
     


### PR DESCRIPTION
Changed the directory removal method in the script to address an issue where os.rmdir() failed when trying to remove non-empty directories. The script was encountering an OSError [WinError 145] because os.rmdir() can only remove empty directories. 

This update uses shutil.rmtree() from the shutil module, which is capable of deleting a directory along with all its contents. This change ensures that the script can successfully remove directories even when they contain files or subdirectories, thus preventing the script from failing and enhancing its robustness in handling directory clean-up tasks.