### PR TITLE
Enhance batch download to specify start and end volumes

### DIFF
--- a/batch.py
+++ b/batch.py
@@ -1,12 +1,13 @@
 url = input("ENTER URL: ")
-url = url[0:len(url)-1]
-print(url)
+startVol = int(url.split("volume-")[1])
+url = url.split("volume-")[0] + "volume-"
+print(url + str(startVol))
 
 from os import system
 
 finalVol = int(input("FINAL VOLUME: "))
 
-for i in range(1, finalVol + 1):
+for i in range(startVol, finalVol + 1):
     print(url + str(i))
 
     system(f"python main.py {url + str(i)}")


### PR DESCRIPTION
Modified the script to allow users to specify both a starting volume and an ending volume for batch downloads. This change addresses the limitation of the previous version, which always started downloading from volume 1.

Updates include:
- Parsing the input URL to extract the current volume number as the starting point (`startVol`).
- Iterating from the `startVol` to `finalVol`, enabling selective downloading of a range of volumes.